### PR TITLE
CM - 169 - moderation improvements fixes

### DIFF
--- a/packages/firebase/functions/src/moderation/business/hideContent.ts
+++ b/packages/firebase/functions/src/moderation/business/hideContent.ts
@@ -54,7 +54,7 @@ export const hideContent = async (hideContentPayload: HideContentPayload): Promi
       flag: FLAGS.hidden,
       reasons: item.moderation?.reasons || [],
       moderatorNote: item.moderation?.moderatorNote || '',
-      quietEnding: item.moderation?.countdownStart || null,
+      quietEnding: item.moderation?.quietEnding || null,
       updatedAt,
       countdownPeriod,
       reporter: userId,

--- a/packages/firebase/functions/src/proposals/business/getNewCountdown.ts
+++ b/packages/firebase/functions/src/proposals/business/getNewCountdown.ts
@@ -9,9 +9,10 @@ import { firestore } from 'firebase-admin';
  */
 export const getNewCountdown = (currCountdown: number, quietEndingPeriod: number) : number => {
 	
-  const now = firestore.Timestamp.now();
-  const countdownHour = (new Date(currCountdown * 1000)).getHours();
-  const diff = (Math.abs((now.toDate()).getHours() - countdownHour)) % 24;
+  const nowMillis = (firestore.Timestamp.now()).toMillis();  
+  const countdownMillis = currCountdown * 1000;
+  
+  const diff = (countdownMillis - nowMillis) / 1000 / 60 / 60;
   
   if (diff > 0 && diff < quietEndingPeriod / 3600) 
   {


### PR DESCRIPTION
This pr has a related frontend pr (but they're not dependent)

frontend pr: https://github.com/daostack/common/pull/1087

ticket: https://github.com/daostack/common-monorepo/issues/169

Calculating the time left using the whole date (including days) and not just hours (before the fix, the calculation ignores day differences, so a 1-hour difference between two dates that are not on the same day, will still go in the `if` clause, because `diff > 0 && diff < quietEndingPeriod / 3600` )