### PR TITLE
URGENT - add TEST flag to emails regarding payments

### DIFF
--- a/packages/firebase/functions/src/notification/email/templates/adminFundingRequestAccepted.ts
+++ b/packages/firebase/functions/src/notification/email/templates/adminFundingRequestAccepted.ts
@@ -62,7 +62,7 @@ const emailStubs = {
 };
 
 export const adminFundingRequestAccepted = {
-  subject: `${testFlag()} Funding proposal was approved`,
+  subject: `${testFlag()}Funding proposal was approved`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/adminFundingRequestAccepted.ts
+++ b/packages/firebase/functions/src/notification/email/templates/adminFundingRequestAccepted.ts
@@ -1,3 +1,5 @@
+import { testFlag } from '../../helpers';
+
 const template = `
 Notice to Admin<br />
 The following proposal was approved and is awaiting payment.
@@ -60,7 +62,7 @@ const emailStubs = {
 };
 
 export const adminFundingRequestAccepted = {
-  subject: 'Funding proposal was approved',
+  subject: `${testFlag()} Funding proposal was approved`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/adminJoinedButFailedPayment.ts
+++ b/packages/firebase/functions/src/notification/email/templates/adminJoinedButFailedPayment.ts
@@ -45,7 +45,7 @@ const emailStubs = {
 };
 
 export const adminJoinedButPaymentFailed = {
-  subject: `${testFlag()} Payment could not be processed`,
+  subject: `${testFlag()}Payment could not be processed`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/adminJoinedButFailedPayment.ts
+++ b/packages/firebase/functions/src/notification/email/templates/adminJoinedButFailedPayment.ts
@@ -1,3 +1,5 @@
+import { testFlag } from '../../helpers';
+
 const template = `
 The following proposal was approved but the payment could not be processed.
 
@@ -43,7 +45,7 @@ const emailStubs = {
 };
 
 export const adminJoinedButPaymentFailed = {
-  subject: 'Payment could not be processed',
+  subject: `${testFlag()} Payment could not be processed`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/approvePayout.ts
+++ b/packages/firebase/functions/src/notification/email/templates/approvePayout.ts
@@ -1,3 +1,5 @@
+import { testFlag } from '../../helpers';
+
 const template = `
 <div>
   Hello stranger,
@@ -59,7 +61,7 @@ const emailStubs = {
 };
 
 export const approvePayout = {
-  subject: 'Approve payout',
+  subject: `${testFlag()} Approve payout`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/approvePayout.ts
+++ b/packages/firebase/functions/src/notification/email/templates/approvePayout.ts
@@ -61,7 +61,7 @@ const emailStubs = {
 };
 
 export const approvePayout = {
-  subject: `${testFlag()} Approve payout`,
+  subject: `${testFlag()}Approve payout`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedForeign.ts
+++ b/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedForeign.ts
@@ -45,7 +45,7 @@ const emailStubs = {
 };
 
 export const userFundingRequestAcceptedForeign = {
-  subject: `${testFlag()} Your funding proposal was approved`,
+  subject: `${testFlag()}Your funding proposal was approved`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedForeign.ts
+++ b/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedForeign.ts
@@ -1,3 +1,5 @@
+import { testFlag } from '../../helpers';
+
 const template = `
 Hello {{userName}},
 <br /><br />
@@ -43,7 +45,7 @@ const emailStubs = {
 };
 
 export const userFundingRequestAcceptedForeign = {
-  subject: 'Your funding proposal was approved',
+  subject: `${testFlag()} Your funding proposal was approved`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedInsufficientFunds.ts
+++ b/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedInsufficientFunds.ts
@@ -30,7 +30,7 @@ const template = `
 `;
 
 export const userFundingRequestAcceptedInsufficientFunds: IEmailTemplate = {
-  subject: `${testFlag()} Your proposal was canceled due to insufficient funds`,
+  subject: `${testFlag()}Your proposal was canceled due to insufficient funds`,
   template: template,
   emailStubs: {
     firstName: {

--- a/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedInsufficientFunds.ts
+++ b/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedInsufficientFunds.ts
@@ -1,4 +1,5 @@
 import { IEmailTemplate } from '..';
+import { testFlag } from '../../helpers';
 
 const template = `
   <div>
@@ -29,7 +30,7 @@ const template = `
 `;
 
 export const userFundingRequestAcceptedInsufficientFunds: IEmailTemplate = {
-  subject: 'Your proposal was canceled due to insufficient funds',
+  subject: `${testFlag()} Your proposal was canceled due to insufficient funds`,
   template: template,
   emailStubs: {
     firstName: {

--- a/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedIsraeli.ts
+++ b/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedIsraeli.ts
@@ -63,7 +63,7 @@ const emailStubs = {
 };
 
 export const userFundingRequestAcceptedIsraeli = {
-  subject: `${testFlag()} ההצעה שלך ב- Common אושרה!`,
+  subject: `${testFlag()}ההצעה שלך ב- Common אושרה!`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedIsraeli.ts
+++ b/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedIsraeli.ts
@@ -1,3 +1,5 @@
+import { testFlag } from '../../helpers';
+
 const template = `<div dir="auto">
 היי {{userName}}, ברכות!
 <br /><br />
@@ -61,7 +63,7 @@ const emailStubs = {
 };
 
 export const userFundingRequestAcceptedIsraeli = {
-  subject: 'ההצעה שלך ב- Common אושרה!',
+  subject: `${testFlag()} ההצעה שלך ב- Common אושרה!`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedUnknown.ts
+++ b/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedUnknown.ts
@@ -42,7 +42,7 @@ const emailStubs = {
 };
 
 export const userFundingRequestAcceptedUnknown = {
-  subject: `${testFlag()} Proposal approved - Missing information`,
+  subject: `${testFlag()}Proposal approved - Missing information`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedUnknown.ts
+++ b/packages/firebase/functions/src/notification/email/templates/userFundingRequestAcceptedUnknown.ts
@@ -1,3 +1,5 @@
+import { testFlag } from '../../helpers';
+
 const template = `
 Hello {{userName}},
 <br /><br />
@@ -40,7 +42,7 @@ const emailStubs = {
 };
 
 export const userFundingRequestAcceptedUnknown = {
-  subject: 'Proposal approved - Missing information',
+  subject: `${testFlag()} Proposal approved - Missing information`,
   emailStubs,
   template
 };

--- a/packages/firebase/functions/src/notification/helpers/index.ts
+++ b/packages/firebase/functions/src/notification/helpers/index.ts
@@ -12,4 +12,4 @@ export const getFundingRequestAcceptedTemplate = (country: string, amount: numbe
 };
 
 //indication the email was sent from staging
-export const testFlag = (): string => env.environment === 'staging' || env.environment === 'dev' ? '[TEST]' : '';
+export const testFlag = (): string => env.environment === 'staging' || env.environment === 'dev' ? '[TEST] ' : '';

--- a/packages/firebase/functions/src/notification/helpers/index.ts
+++ b/packages/firebase/functions/src/notification/helpers/index.ts
@@ -12,4 +12,4 @@ export const getFundingRequestAcceptedTemplate = (country: string, amount: numbe
 };
 
 //indication the email was sent from staging
-export const testFlag = (): string => env.environment === 'staging' ? '[TEST]' : ''
+export const testFlag = (): string => env.environment === 'staging' || env.environment === 'dev' ? '[TEST]' : '';

--- a/packages/firebase/functions/src/notification/helpers/index.ts
+++ b/packages/firebase/functions/src/notification/helpers/index.ts
@@ -1,3 +1,5 @@
+import { env } from '../../constants';
+
 export const getFundingRequestAcceptedTemplate = (country: string, amount: number): string => {
   if (amount) {
     return !country
@@ -8,3 +10,6 @@ export const getFundingRequestAcceptedTemplate = (country: string, amount: numbe
   }
   return 'userFundingRequestAcceptedZeroAmount';
 };
+
+//indication the email was sent from staging
+export const testFlag = (): string => env.environment === 'staging' ? '[TEST]' : ''


### PR DESCRIPTION
Jonathan asked to add a TEST flag the fundings and payout emails to admin so he would know not to actually process the payment

Ticket: https://github.com/daostack/common-monorepo/issues/532